### PR TITLE
Fix invalid time cues

### DIFF
--- a/tests/subtitles/youtube_dl.vtt
+++ b/tests/subtitles/youtube_dl.vtt
@@ -1,0 +1,24 @@
+WEBVTT
+Kind: captions
+Language: en
+Style:
+::cue(c.colorCCCCCC) { color: rgb(204,204,204);
+ }
+::cue(c.colorE5E5E5) { color: rgb(229,229,229);
+ }
+##
+
+
+00:04:46.070 --> 00:04:46.470 align:start position:0%
+yeah
+
+
+00:04:46.470 --> 00:05:04.080 align:start position:0%
+yeah
+<c.colorCCCCCC>what</c>
+00:05:04.080 --> 00:05:05.069 align:start position:0%
+this<00:05:04.199><c> will</c><c.colorE5E5E5><00:05:04.379><c> happen</c></c><c.colorCCCCCC><00:05:04.620><c> is</c><00:05:04.860><c> I'm</c><00:05:05.069><c> telling</c></c>
+
+00:05:05.069 --> 00:05:05.400 align:start position:0%
+this will<c.colorE5E5E5> happen</c><c.colorCCCCCC> is I'm telling
+ </c>

--- a/tests/webvtt_parser.py
+++ b/tests/webvtt_parser.py
@@ -58,11 +58,9 @@ class WebVTTParserTestCase(GenericParserTestCase):
         )
 
     def test_webvtt_parse_invalid_timeframe_in_cue_text(self):
-        self.assertRaises(
-            MalformedCaptionError,
-            webvtt.read,
-            self._get_file('invalid_timeframe_in_cue_text.vtt')
-        )
+        vtt = webvtt.read(self._get_file('invalid_timeframe_in_cue_text.vtt'))
+        self.assertEqual(4, len(vtt.captions))
+        self.assertEqual('', vtt.captions[1].text)
 
     def test_webvtt_parse_get_caption_data(self):
         vtt = webvtt.read(self._get_file('one_caption.vtt'))
@@ -161,4 +159,11 @@ class WebVTTParserTestCase(GenericParserTestCase):
         self.assertEqual(
             vtt.captions[-2].text,
             "Diez años no son suficientes\npara olvidarte..."
+        )
+
+    def test_can_parse_youtube_dl_files(self):
+        vtt = webvtt.read(self._get_file('youtube_dl.vtt'))
+        self.assertEqual(
+            "this will happen is I'm telling",
+            vtt.captions[2].text
         )

--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -163,11 +163,12 @@ class WebVTTParser(TextBasedParser):
                 blocks.append(Block(index))
 
         # filter out empty blocks and skip signature
-        self.blocks = list(filter(lambda x: x.lines, blocks))[1:]
+        return list(filter(lambda x: x.lines, blocks))[1:]
 
     def _parse_cue_block(self, block):
         caption = Caption()
         cue_timings = None
+        additional_blocks = None
 
         for line_number, line in enumerate(block.lines):
             if self._is_cue_timings_line(line):
@@ -178,8 +179,13 @@ class WebVTTParser(TextBasedParser):
                         raise MalformedCaptionError(
                             '{} in line {}'.format(e, block.line_number + line_number))
                 else:
-                    raise MalformedCaptionError(
-                        '--> found in line {}'.format(block.line_number + line_number))
+                    additional_blocks = self._compute_blocks(
+                        ['WEBVTT', '\n'] + block.lines[line_number:]
+                    )
+                    break
+                    # TODO: Is there a time we still might want this?
+                    # raise MalformedCaptionError(
+                    #    '--> found in line {}'.format(block.line_number + line_number))
             elif line_number == 0:
                 caption.identifier = line
             else:
@@ -187,19 +193,25 @@ class WebVTTParser(TextBasedParser):
 
         caption.start = cue_timings[0]
         caption.end = cue_timings[1]
-        return caption
+        return caption, additional_blocks
 
     def _parse(self, lines):
         self.captions = []
-        self._compute_blocks(lines)
+        blocks = self._compute_blocks(lines)
+        self._parseBlocks(blocks)
 
-        for block in self.blocks:
+    def _parseBlocks(self, blocks):
+        for block in blocks:
             # skip empty blocks
             if self._is_empty(block):
                 continue
             if self._is_cue_block(block):
-                caption = self._parse_cue_block(block)
+                caption, additional_blocks = self._parse_cue_block(block)
                 self.captions.append(caption)
+
+                if additional_blocks:
+                    self._parseBlocks(additional_blocks)
+
             elif self._is_comment_block(block):
                 continue
             elif self._is_style_block(block):


### PR DESCRIPTION
This is built on top of #18 because the code touches the same places and would've conflicted otherwise.

It fixes #13 if we want to support invalid formats.