### PR TITLE
add support for parsing HLS WebVTT X-TIMESTAMP-MAP tag

### DIFF
--- a/webvtt/errors.py
+++ b/webvtt/errors.py
@@ -16,3 +16,7 @@ class InvalidCaptionsError(Exception):
 
 class MissingFilenameError(Exception):
     """Error raised when saving a file without filename."""
+
+class HlsTimeMapError(Exception):
+    """Error raised when an Hls Timestamp map is malformed"""
+

--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -3,7 +3,7 @@ import os
 import codecs
 
 from .errors import MalformedFileError, MalformedCaptionError
-from .structures import Block, Style, Caption
+from .structures import Block, Style, Caption, TimestampMap
 
 
 class TextBasedParser(object):
@@ -249,6 +249,15 @@ class WebVTTParser(TextBasedParser):
         """Returns True if it is a style block"""
         return re.match(self.STYLE_PATTERN, block.lines[0])
 
+class HlsWebVTTParser(WebVTTParser):
+    """
+    HLS WebVTT parser. Support X-TIMESTAMP-MAP tag
+    """
+    def _parse(self, lines):
+        self.timestamp_map = TimestampMap(
+            next(line for line in lines if line.upper().startswith('X-TIMESTAMP-MAP'))
+        )
+        super(HlsWebVTTParser, self)._parse(lines)
 
 class SBVParser(TextBasedParser):
     """

--- a/webvtt/structures.py
+++ b/webvtt/structures.py
@@ -1,10 +1,57 @@
 import re
 
-from .errors import MalformedCaptionError
+from .errors import MalformedCaptionError, HlsTimeMapError
 
 TIMESTAMP_PATTERN = re.compile('(\d+)?:?(\d{2}):(\d{2})[.,](\d{3})')
 
+TIMESTAMP_MAP_LOCAL_PATTERN = re.compile(
+    'X-TIMESTAMP-MAP\=.*?LOCAL\:(?P<local>(\d+)?:?(\d{2}):(\d{2})[.,](\d{3}))',
+    re.IGNORECASE
+)
+
+TIMESTAMP_MAP_MPEGTS_PATTERN = re.compile(
+    'X-TIMESTAMP-MAP\=.*?MPEGTS\:(?P<mpegts>(\d+))',
+    re.IGNORECASE
+)
 __all__ = ['Caption']
+
+class TimestampMap(object):
+    def __init__(self, raw_timestamp_map):
+        if 'X-TIMESTAMP-MAP' not in raw_timestamp_map:
+            raise HlsTimeMapError('X-TIMESTAMP-MAP tag not found')
+        self._raw = raw_timestamp_map
+
+    @property
+    def local(self):
+        regex = re.search(
+            TIMESTAMP_MAP_LOCAL_PATTERN,
+            self._raw,
+        )
+        if regex is None:
+            return None
+        else:
+            try:
+                return regex.group('local')
+            except (AttributeError,IndexError) as e:
+                return None
+            except Exception as e:
+                raise HlsTimeMapError('could not parse LOCAL') from e
+
+    @property
+    def mpegts(self):
+        regex = re.search(
+            TIMESTAMP_MAP_MPEGTS_PATTERN,
+            self._raw,
+        )
+        if regex is None:
+            return None
+        else:
+            try:
+                return regex.group('mpegts')
+            except (AttributeError,IndexError) as e:
+                return None
+            except Exception as e:
+                raise HlsTimeMapError('could not parse MPEGTS') from e
 
 
 class Caption(object):

--- a/webvtt/webvtt.py
+++ b/webvtt/webvtt.py
@@ -1,6 +1,6 @@
 import os
 
-from .parsers import WebVTTParser, SRTParser, SBVParser
+from .parsers import WebVTTParser, HlsWebVTTParser, SRTParser, SBVParser
 from .writers import WebVTTWriter, SRTWriter
 from .errors import MissingFilenameError
 
@@ -131,3 +131,27 @@ class WebVTT(object):
     @property
     def styles(self):
         return self._styles
+
+class HlsWebVTT(WebVTT):
+    def __init__(self, file='', captions=None, styles=None, timestamp_map=None):
+        self._timestamp_map = timestamp_map
+        super(HlsWebVTT, self).__init__(file,captions, styles)
+
+    @property
+    def timestamp_map(self):
+        return self._timestamp_map
+
+    @classmethod
+    def read(cls, file):
+        """Reads a WebVTT captions file."""
+        parser = HlsWebVTTParser().read(file)
+        return cls(file=file, captions=parser.captions, styles=parser.styles, timestamp_map=parser.timestamp_map)
+
+    @classmethod
+    def read_buffer(cls, buffer):
+        """Reads a WebVTT captions from a file-like object.
+        Such file-like object may be the return of an io.open call,
+        io.StringIO object, tempfile.TemporaryFile object, etc."""
+        parser = HlsWebVTTParser().read_from_buffer(buffer)
+        return cls(captions=parser.captions, styles=parser.styles, timestamp_map=parser.timestamp_map)
+


### PR DESCRIPTION
Adding support for parsing HLS WebVTT X-TIMESTAMP-MAP tag.
for more details see: https://tools.ietf.org/html/rfc8216#section-3.5 