### PR TITLE
Allow parsing of empty SBV captions

### DIFF
--- a/tests/sbv_parser.py
+++ b/tests/sbv_parser.py
@@ -39,11 +39,7 @@ class SBVParserTestCase(GenericParserTestCase):
         )
 
     def test_sbv_missing_caption_text(self):
-        self.assertRaises(
-            webvtt.errors.MalformedCaptionError,
-            webvtt.from_sbv,
-            self._get_file('missing_caption_text.sbv')
-        )
+        self.assertTrue(webvtt.from_sbv(self._get_file('missing_caption_text.sbv')).captions)
 
     def test_sbv_invalid_timestamp(self):
         self.assertRaises(

--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -261,6 +261,10 @@ class SBVParser(TextBasedParser):
 
     TIMEFRAME_LINE_PATTERN = re.compile('\s*(\d+:\d{2}:\d{2}.\d{3}),(\d+:\d{2}:\d{2}.\d{3})')
 
+    PARSER_OPTIONS = {
+        'ignore_empty_captions': True
+    }
+
     def _validate(self, lines):
         if not self._validate_timeframe_line(lines[0]):
             raise MalformedFileError('The file does not have a valid format')


### PR DESCRIPTION
YouTube allows uploading of empty SBV captions. This PR is to add that ability for SBV files.