### PR TITLE
add property to get webvtt content without needing a file

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+0.4.6
+------------------
+
+* Add capability to get WebVTT formatted content without an output file
+
 0.4.5 (09-04-2020)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -119,6 +119,21 @@ Saving captions
         vtt.write(fd)
 
 
+Fetching WebVTT formatted Captions
+------------------------------------
+
+WebVTT formatted captions content can be obtained without having to create an output file.
+
+.. code-block:: python
+
+    import webvtt
+
+    vtt = webvtt.read('captions.vtt')
+
+    # Print the captions formatted in webvtt
+    print(vtt.content)
+
+
 Converting captions
 -------------------
 

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -393,3 +393,25 @@ class WebVTTTestCase(GenericParserTestCase):
         ]
 
         self.assertListEqual(lines, expected_lines)
+
+    def test_content_formatting(self):
+        """
+        Verify that content property returns the correctly formatted webvtt.
+        """
+        captions = [
+            Caption('00:00:00.500', '00:00:07.000', ['Caption test line 1', 'Caption test line 2']),
+            Caption('00:00:08.000', '00:00:15.000', ['Caption test line 3', 'Caption test line 4']),
+        ]
+        expected_content = textwrap.dedent("""\
+                WEBVTT
+
+                00:00:00.500 --> 00:00:07.000
+                Caption test line 1
+                Caption test line 2
+                   
+                00:00:08.000 --> 00:00:15.000
+                Caption test line 3
+                Caption test line 4
+                """).strip()
+        vtt = webvtt.WebVTT(captions=captions)
+        self.assertEqual(expected_content, vtt.content)

--- a/webvtt/__init__.py
+++ b/webvtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
 from .webvtt import *
 from .segmenter import *

--- a/webvtt/webvtt.py
+++ b/webvtt/webvtt.py
@@ -131,3 +131,13 @@ class WebVTT(object):
     @property
     def styles(self):
         return self._styles
+
+    @property
+    def content(self):
+        """
+        Return webvtt content with webvtt formatting.
+
+        This property is useful in cases where the webvtt content is needed
+        but no file saving on the system is required.
+        """
+        return WebVTTWriter().webvtt_content(self._captions)

--- a/webvtt/writers.py
+++ b/webvtt/writers.py
@@ -2,12 +2,20 @@
 class WebVTTWriter(object):
 
     def write(self, captions, f):
-        f.write('WEBVTT\n')
-        for c in captions:
-            if c.identifier:
-                f.write('\n' + c.identifier)
-            f.write('\n{} --> {}\n'.format(c.start, c.end))
-            f.writelines(['{}\n'.format(l) for l in c.lines])
+        f.write(self.webvtt_content(captions))
+
+    def webvtt_content(self, captions):
+        """
+        Return captions content with webvtt formatting.
+        """
+        output = ["WEBVTT"]
+        for caption in captions:
+            output.append("")
+            if caption.identifier:
+                output.append(caption.identifier)
+            output.append('{} --> {}'.format(caption.start, caption.end))
+            output.extend(caption.lines)
+        return '\n'.join(output)
 
 
 class SRTWriter(object):


### PR DESCRIPTION
### Description

This PR adds a property `content` in **WebVTT** object to obtain the formatted vtt without the need to create a .vtt file on the system. This can be helpful in cases when the data needs to be saved on a remote server and not on the hosted server. The addition of property will remove the overhead of creating a temporary vtt file and then reading the content from it. 

### Unit Tests Result
![image](https://user-images.githubusercontent.com/40599381/98129928-84d2a300-1edb-11eb-8444-6aea5cf23346.png)
