### PR TITLE
Match MS Teams timestamp format

### DIFF
--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -155,7 +155,10 @@ class WebVTTParser(TextBasedParser):
     WebVTT parser.
     """
 
-    TIMEFRAME_LINE_PATTERN = re.compile(r'\s*((?:\d+:)?\d{2}:\d{2}.\d{3})\s*-->\s*((?:\d+:)?\d{2}:\d{2}.\d{3})')
+    TIMEFRAME_LINE_PATTERN = re.compile(
+        # matches timestamp format: 0:0:13.540 --> 0:0:17.850
+        r'\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{1,3})\s*-->\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{1,3})'
+    )
     COMMENT_PATTERN = re.compile(r'NOTE(?:\s.+|$)')
     STYLE_PATTERN = re.compile(r'STYLE[ \t]*$')
 

--- a/webvtt/parsers.py
+++ b/webvtt/parsers.py
@@ -157,7 +157,7 @@ class WebVTTParser(TextBasedParser):
 
     TIMEFRAME_LINE_PATTERN = re.compile(
         # matches timestamp format: 0:0:13.540 --> 0:0:17.850
-        r'\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{1,3})\s*-->\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{1,3})'
+        r'\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{3})\s*-->\s*((?:\d+:)?\d{1,2}:\d{1,2}.\d{3})'
     )
     COMMENT_PATTERN = re.compile(r'NOTE(?:\s.+|$)')
     STYLE_PATTERN = re.compile(r'STYLE[ \t]*$')


### PR DESCRIPTION
Hi,

Microsoft Teams produces a timestamp format that appears to meet the WebVtt standard but the currently existing regular expression does not match against it. 

The Team's timestamp format: 0:0:13.540 --> 0:0:17.850

This PR attempts to expand the regular expression to match this case.