### PR TITLE
Fix slice_segments #36

### DIFF
--- a/webvtt/segmenter.py
+++ b/webvtt/segmenter.py
@@ -3,7 +3,7 @@
 import typing
 import os
 import pathlib
-from math import ceil, floor
+from math import floor
 
 from .webvtt import WebVTT, Caption
 
@@ -49,7 +49,7 @@ def slice_segments(
     total_segments = (
         0
         if not captions else
-        int(ceil(captions[-1].end_in_seconds / seconds))
+        floor(captions[-1].end_in_seconds / seconds) + 1
     )
 
     segments: typing.List[typing.List[Caption]] = [


### PR DESCRIPTION
Fix #36 

The IndexError occurs when the `end_in_seconds` of the last caption is divisible by the `seconds` value (the number of seconds for each segment).

### captions.vtt

```vtt
WEBVTT

00:00.000 --> 00:09.000
It's OK.

00:09.000 --> 00:10.000
Fix me!
```

### CLI

```sh
$ webvtt segment captions.vtt --output output/path
```
